### PR TITLE
mark unused variables

### DIFF
--- a/Guts/emulation.h
+++ b/Guts/emulation.h
@@ -162,6 +162,7 @@ ML_INLINE int emu_mm_testnzc_si128(const __m128i& x, const __m128i& y) {
 
 template <int32_t imm>
 ML_INLINE __m128 emu_mm_round_ps(const __m128& x) {
+    ML_Unused(x);
     ML_StaticAssertMsg(imm != imm, "Unsupported rounding mode!");
 
     return _mm_setzero_ps();
@@ -199,6 +200,7 @@ ML_INLINE __m128 emu_mm_round_ps<_MM_FROUND_CEIL | ML_ROUNDING_EXEPTIONS_MASK>(c
 
 template <int32_t imm>
 ML_INLINE __m128d emu_mm_round_pd(const __m128d& x) {
+    ML_Unused(x);
     ML_StaticAssertMsg(imm != imm, "Unsupported rounding mode!");
 
     return _mm_setzero_pd();
@@ -238,6 +240,7 @@ ML_INLINE __m128d emu_mm_round_pd<_MM_FROUND_CEIL | ML_ROUNDING_EXEPTIONS_MASK>(
 
 template <int32_t imm>
 ML_INLINE __m128 emu_mm_dp_ps(const __m128& x, const __m128& y) {
+    ML_Unused(x, y);
     ML_StaticAssertMsg(imm != imm, "Unsupported dp mode!");
 
     return _mm_setzero_ps();


### PR DESCRIPTION
whenever i compile mathlib i get warnings about unused variables - and one of my dependencies sets warnings-as-errors, so these warnings fail my build

this pr marks the offending variables as unused, using mathlib's existing `ML_Unused` macro. this lets me compile mathlib without needing to modify the on-disk sources

i'm compiling with clang 21.1.8, on fedora 43 - other compilers may be less strict about this stuff